### PR TITLE
Add looping functionality - iOS Only

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,11 @@ Only available on iOS. Overwrite default audio output to speaker, which forces `
 
 Set the volume of the current player. This does not change the volume of the device.
 
+
+### `setNumberOfLoops(volume: number)` - iOS Only
+
+Set the number of loops. A negative value will loop indefinitely until the `stop()` command is called.
+
 ### `getInfo() => Promise<{currentTime: number, duration: number}>`
 
 Get the `currentTime` and `duration` of the currently mounted audio media. This function returns a promise which resolves to an Object containing `currentTime` and `duration` properties.

--- a/index.js
+++ b/index.js
@@ -20,6 +20,10 @@ export default {
     RNSoundPlayer.loadSoundFile(name, type)
   },
 
+  setNumberOfLoops: (loops: number) => {
+    RNSoundPlayer.setNumberOfLoops(loops);
+  },
+
   playUrl: (url: string) => {
     RNSoundPlayer.playUrl(url)
   },

--- a/ios/RNSoundPlayer.h
+++ b/ios/RNSoundPlayer.h
@@ -11,4 +11,5 @@
 @interface RNSoundPlayer : RCTEventEmitter <RCTBridgeModule, AVAudioPlayerDelegate>
 @property (nonatomic, strong) AVAudioPlayer *player;
 @property (nonatomic, strong) AVPlayer *avPlayer;
+@property (nonatomic, strong) int loopCount;
 @end

--- a/ios/RNSoundPlayer.m
+++ b/ios/RNSoundPlayer.m
@@ -138,7 +138,7 @@ RCT_REMAP_METHOD(getInfo,
     NSURL *soundFileURL = [NSURL fileURLWithPath:soundFilePath];
     self.player = [[AVAudioPlayer alloc] initWithContentsOfURL:soundFileURL error:nil];
     [self.player setDelegate:self];
-    [self.player setNumberOfLoops:0];
+    [self.player setNumberOfLoops:self.loopCount];
     [self.player prepareToPlay];
     [[AVAudioSession sharedInstance]
             setCategory: AVAudioSessionCategoryPlayback


### PR DESCRIPTION
Adds the ability to loop a fixed amount (or indefinitely) any audio file played through the SoundPlayer.